### PR TITLE
Fix Rpi4 package building

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,18 +13,18 @@ provides=('argonone')
 install=argonone.install
 
 source=(
-  "https://raw.githubusercontent.com/Elrondo46/argonone/master/argonone-config"
-  "https://raw.githubusercontent.com/Elrondo46/argonone/master/argononed-poweroff.py"
-  "https://raw.githubusercontent.com/Elrondo46/argonone/master/argononed.conf"
-  "https://raw.githubusercontent.com/Elrondo46/argonone/master/argononed.py"
-  "https://raw.githubusercontent.com/Elrondo46/argonone/master/argononed.service"
+  "https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argonone-config"
+  "https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argononed-poweroff.py"
+  "https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argononed.conf"
+  "https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argononed.py"
+  "https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argononed.service"
   )
 
 sha256sums=(
   "41831f2796691322131061a23a2c61b01d9d124416854963a2ba9c47a72d0850"
   "a8ecb1a581bbc8b1d705b63797d5521cac92f87a53d087eb148de877957abc55"
   "f6f82283a286c9694a5adc6db842fca2e75845f1ccf0bacfb7ce2efa3c8eaec3"
-  "6a82dd456f02ec5f2de4dc9974eed847670247c9dbf120124acfa6c0b6e5713f"
+  "33c86ea67e54082cc8627930567c127b61d30cafb979eccda32403a0a0587d12"
   "1db1bc647690db29339ef4317b10738fe7fdbc379aad2149c9d0d353c42a3db4"
 )
 

--- a/argonone.install
+++ b/argonone.install
@@ -3,7 +3,7 @@ pre_install() {
   if grep "Raspberry Pi 4" /proc/device-tree/model ; then
     echo "Building New Virtual Environment in /opt/argonone..."
     python -m venv --clear /opt/argonone
-    /opt/argonone/bin/python3 -m pip install pysmbus RPi.GPIO
+    /opt/argonone/bin/python3 -m pip install pysmbus RPi.GPIO --use-deprecated=legacy-resolver
 
     echo "Enabling i2C..."
     BOOT_CFG="/boot/config.txt"

--- a/argononed.py
+++ b/argononed.py
@@ -93,9 +93,8 @@ def temp_check():
     address = 0x1a
     prevblock = 0
     while True:
-        temp = os.popen("/opt/vc/bin/vcgencmd measure_temp").readline()
-        temp = temp.replace("temp=", "")
-        val = float(temp.replace("'C", ""))
+        temp = os.popen("cat /sys/class/thermal/thermal_zone0/temp").readline()
+        val = float(temp) / 1000
         block = get_fanspeed(val, fanconfig)
         if block < prevblock:
             time.sleep(30)


### PR DESCRIPTION
- Use repos in PKGBUILD from kounch instead of elrondo46 repo in rpi4 branch. 

- Adds the temp read as lisa did in https://github.com/Elrondo46/argonone/commit/8cef479ce0035921e98933e83717c28cb1b93615 

- Also , when trying to install for rpi4 , it cannot install pysmbus

```
argonone-python-arch]$ sudo pacman -U argonone-rpi4-20191209-1-any.pkg.tar.xz 
Es carreguen paquets...
Es resolen les dependències...
Se cerquen els paquets conflictius...

Paquets (1) argonone-rpi4-20191209-1

Mida total de la instal·lació:  0,01 MiB

:: N'inicio la instal·lació? [S/n] 
(1/1) Es comproven les claus del clauer.                                                                   [################################################################] 100%
(1/1) Es comprova la integritat dels paquets.                                                              [################################################################] 100%
(1/1) Es carreguen els fitxers dels paquets.                                                               [################################################################] 100%
(1/1) Es comproven els conflictes entre els fitxers.                                                       [################################################################] 100%
(1/1) Es comprova l'espai disponible al disc.                                                              [################################################################] 100%
:: Es processen els canvis dels paquets...
Checking Hardware Model...
grep: /proc/device-tree/model: binary file matches
Building New Virtual Environment in /opt/argonone...
Collecting pysmbus
  Downloading pysmbus-0.1-3.tar.gz (2.4 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Discarding https://files.pythonhosted.org/packages/a1/d8/68240a0e2a9ae5b67a08014d5ba183ac312cc65cfe52eec5e6048d377e6d/pysmbus-0.1-3.tar.gz (from https://pypi.org/simple/pysmbus/): Requested pysmbus from https://files.pythonhosted.org/packages/a1/d8/68240a0e2a9ae5b67a08014d5ba183ac312cc65cfe52eec5e6048d377e6d/pysmbus-0.1-3.tar.gz has inconsistent version: filename has '0.1.post3', but metadata has '0.1'
ERROR: Could not find a version that satisfies the requirement pysmbus (from versions: 0.1.post3)
ERROR: No matching distribution found for pysmbus
```
Adding legacy-resolver in pip install in argonone.install fixes it:

`/opt/argonone/bin/python3 -m pip install pysmbus RPi.GPIO --use-deprecated=legacy-resolver `



NOTE:

Obviously is  not possible to build the package before this PR is merged to `feature/RaspberryPi4`, as sha256sum will not pass. so to check it out before merging one must change the source of the changed file. 
```diff
-"https://raw.githubusercontent.com/kounch/argonone/feature/RaspberryPi4/argononed.p
y"
+"https://raw.githubusercontent.com/aleixq/argonone/feature/RaspberryPi4/argononed.p
y"
```
(or tell pkgbuild to skip the sha256 check) 